### PR TITLE
0.7.14 - Allow use ReactNode in checkbox's label. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/Checkbox.tsx
+++ b/src/core/Checkbox.tsx
@@ -3,12 +3,12 @@ import {
     FormControlLabel as MuiFormControlLabel,
     Switch as MuiSwitch
 } from '@material-ui/core'
-import React, { ChangeEvent, Component } from 'react'
+import React, { ChangeEvent, Component, ReactNode } from 'react'
 import { IDefault } from './Advertise'
 
 interface IProps extends IDefault {
     name: string
-    label?: string
+    label?: ReactNode
     color?: 'primary' | 'secondary' | 'default'
     className?: string
     disabled?: boolean


### PR DESCRIPTION
Allow uses ReactNode in checkbox's label. 