### PR TITLE
0.7.15 - Allow target (optional) use in the Button component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/Button.tsx
+++ b/src/core/Button.tsx
@@ -13,6 +13,7 @@ interface IProps extends IDefault {
     href?: string
     fullWidth?: boolean
     variant?: 'text' | 'flat' | 'outlined' | 'contained' | 'fab' | 'extendedFab' | 'dashed'
+    target?: string
     children?: ReactNode
     onClick?: (event?) => void
 }


### PR DESCRIPTION
Target allowed for buttons, it's could be necessary for point to external address.