### PR TITLE
0.8.9 - Add type JSX.Element to step label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/Stepper.tsx
+++ b/src/core/Stepper.tsx
@@ -14,7 +14,7 @@ interface IProps extends IDefault {
 }
 
 type TStep = {
-    label: JSX.Element | string | ((active?: boolean) => JSX.Element)
+    label: JSX.Element | string
     icon: JSX.Element | ((active?: boolean) => JSX.Element)
 }
 

--- a/src/core/Stepper.tsx
+++ b/src/core/Stepper.tsx
@@ -14,7 +14,7 @@ interface IProps extends IDefault {
 }
 
 type TStep = {
-    label: JSX.Element | string
+    label: JSX.Element | string | ((active?: boolean) => JSX.Element)
     icon: JSX.Element | ((active?: boolean) => JSX.Element)
 }
 

--- a/src/core/Stepper.tsx
+++ b/src/core/Stepper.tsx
@@ -14,7 +14,7 @@ interface IProps extends IDefault {
 }
 
 type TStep = {
-    label: string
+    label: JSX.Element | string
     icon: JSX.Element | ((active?: boolean) => JSX.Element)
 }
 


### PR DESCRIPTION
Add type JSX.Element to step label for allow the use of other elements as label. 