### PR TITLE
0.9.0 - Insert MaskField 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "color": "3.0.0",
     "downshift": "2.2.3",
     "fs-extra": "7.0.0",
-    "ramda": "0.25.0"
+    "ramda": "0.25.0",
+    "react-number-format": "4.0.8"
   },
   "devDependencies": {
     "@types/node": "10.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.8.16",
+  "version": "0.9.0",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/MaskField.tsx
+++ b/src/core/MaskField.tsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import TextField, { IProps } from './TextField'
+import NumberFormat from 'react-number-format'
+
+interface IMaskProps {
+    mask?: string
+    type?: 'text' | 'tel' | 'password'
+    decimalSeparator?: string
+    format: string
+}
+
+class MaskField extends Component<IProps & IMaskProps> {
+    public render() {
+        return (
+            // Although react-number-format allow use of additional props,
+            // shows problem with some props like have been do this
+            // actually on flipper-ui. (e.g. errors treatment)
+            // @ts-ignore
+            <NumberFormat
+                { ...this.props }
+                customInput={ TextField }>
+            </NumberFormat>
+        )
+    }
+}
+
+export default MaskField

--- a/src/docz/MaskField.mdx
+++ b/src/docz/MaskField.mdx
@@ -22,7 +22,7 @@ import { Playground, PropsTable } from 'docz'
 <Playground>
     <MaskField
         mask='_'
-        format='##:##'
+        format='##.##'
         label='Price'
         InputProps={ {
             startAdornment: <InputAdornment position='start'>$</InputAdornment>

--- a/src/docz/MaskField.mdx
+++ b/src/docz/MaskField.mdx
@@ -1,0 +1,32 @@
+---
+name: MaskField
+route: /mask-field
+---
+
+import InputAdornment from '../core/InputAdornment'
+import MaskField from '../core/MaskField'
+import ListItem from '../core/ListItem'
+import { Playground, PropsTable } from 'docz'
+
+# MaskField
+
+## Properties
+<PropsTable of={ MaskField } />
+
+## Simple MaskField
+<Playground>
+    <MaskField placeholder='Description' />
+</Playground>
+
+## MaskField with InputAdornment
+<Playground>
+    <MaskField
+        mask='_'
+        format='##:##'
+        label='Price'
+        InputProps={ {
+            startAdornment: <InputAdornment position='start'>$</InputAdornment>
+        } }
+        InputLabelProps={ { shrink: true } }
+    />
+</Playground>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6638,7 +6638,7 @@ react-live@^1.11.0:
     prop-types "^15.5.8"
     unescape "^0.2.0"
 
-react-number-format@^4.0.8:
+react-number-format@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.0.8.tgz#f0a0dfbeded9a746f4d8b309926cf55d7effebb2"
   integrity sha512-A7Gi4BSkdgnyY1DO98lwFvWujcyxZCOfNP6tkiOKkwMY6oFP+JTQhd/vQ9dXXs6TpyXfl1eBJdueokM7o98YTQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6361,6 +6361,15 @@ prop-types@15.6.2, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, p
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -6605,7 +6614,7 @@ react-is@^16.3.1:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
 
-react-is@^16.6.3, react-is@^16.7.0:
+react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -6628,6 +6637,13 @@ react-live@^1.11.0:
     prismjs "1.6"
     prop-types "^15.5.8"
     unescape "^0.2.0"
+
+react-number-format@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.0.8.tgz#f0a0dfbeded9a746f4d8b309926cf55d7effebb2"
+  integrity sha512-A7Gi4BSkdgnyY1DO98lwFvWujcyxZCOfNP6tkiOKkwMY6oFP+JTQhd/vQ9dXXs6TpyXfl1eBJdueokM7o98YTQ==
+  dependencies:
+    prop-types "^15.7.2"
 
 react-perfect-scrollbar@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
- Now is possible use number masks in flipper-ui, format prop is required for use this component.  
- Although react-number-format allow use of additional props, shows problem with some props like have been do this actually on flipper-ui. (e.g. errors treatment)