### PR TITLE
0.16.3 - Bumb typescript to 3.5.1 and @material-ui/pickers to 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@date-io/date-fns": "1.3.6",
     "@material-ui/core": "4.0.1",
     "@material-ui/icons": "4.0.1",
-    "@material-ui/pickers": "3.0.0",
+    "@material-ui/pickers": "3.2.3",
     "color": "3.0.0",
     "date-fns": "2.0.0-alpha.27",
     "fs-extra": "7.0.0",
@@ -60,7 +60,7 @@
     "gh-pages": "2.0.0",
     "prettier": "1.16.4",
     "styled-components": "3.4.9",
-    "typescript": "3.3.1"
+    "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,14 +1075,14 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
 
-"@material-ui/pickers@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.0.0.tgz#cd99933e5701fa5aeea1862418b43fc399398e15"
-  integrity sha512-tjnKWHudaZ089Gsxvio/8DxDVUmPIx/RRi1O66haAGGJmahoI9ICDU8lwpoU828nY7f3mQN7lSrca9bdAdrLoA==
+"@material-ui/pickers@3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.3.tgz#84ef0262f15d882d36bcee3b16d1ac480fb53c04"
+  integrity sha512-qtFmEyP6vKUSAbpBkgKlZkeCZgll0YEQZu351k/Ates57UYLeoJyM2CNCsRxif1w91qVoYB7CPskIdUrCpcMmg==
   dependencies:
+    "@babel/runtime" "^7.2.0"
     "@types/styled-jsx" "^2.2.8"
     clsx "^1.0.2"
-    react-event-listener "^0.6.6"
     react-transition-group "^4.0.0"
     rifm "^0.7.0"
     tslib "^1.9.3"
@@ -9078,15 +9078,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
-  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
-
 typescript@3.3.4000:
   version "3.3.4000"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
   integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
To solve this:

before
![issue](https://user-images.githubusercontent.com/11683201/63522603-13255980-c4cf-11e9-825a-2c2975b13737.png)

after
![new](https://user-images.githubusercontent.com/11683201/63522606-16204a00-c4cf-11e9-9896-46ced79414ec.png)
