### PR TITLE
0.16.6 - Add row option to RadioGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/RadioGroup.tsx
+++ b/src/core/RadioGroup.tsx
@@ -5,14 +5,15 @@ import {
     Radio,
     RadioGroup as MuiRadioGroup
 } from '@material-ui/core'
-import React, { ChangeEvent, FC } from 'react'
+import React, { ChangeEvent, FC, ReactNode } from 'react'
 import { IDefault } from './Advertise'
 
 interface IProps extends IDefault {
-    title?: string
+    row?: boolean
+    title?: ReactNode
     name: string
     value?: string
-    options?: Array<{ value: string, label?: string }>
+    options?: Array<{ value: string, label?: ReactNode }>
     onChange?: (event: ChangeEvent<HTMLElement>) => void
 }
 


### PR DESCRIPTION
- Added `row` prop that allows us to set RadioGroup orientation to horizontal
- Added `spacing` prop with two options: `default` and `equal`
    - `default` spacing:
![default_spacing](https://user-images.githubusercontent.com/19315347/63617492-06346300-c5c0-11e9-884d-2800f824c8c9.png)

    - `equal` spacing:
![equal_spacing](https://user-images.githubusercontent.com/19315347/63617493-06ccf980-c5c0-11e9-9940-1a948a4b6ebb.png)
