### PR TITLE
0.19.0 - Remove imports of locales (date-fns)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@material-ui/icons": "4.4.3",
     "@material-ui/pickers": "3.2.6",
     "color": "3.0.0",
-    "date-fns": "2.0.0-alpha.27",
+    "date-fns": "2.4.1",
     "fs-extra": "7.0.0",
     "ramda": "0.25.0",
     "react-number-format": "4.0.8"

--- a/src/core/DateTime.tsx
+++ b/src/core/DateTime.tsx
@@ -7,9 +7,6 @@ import {
 } from '@material-ui/pickers'
 import DateFnsUtils from '@date-io/date-fns'
 import { IDefault } from './Advertise'
-import ptLocale from 'date-fns/locale/pt-BR'
-import esLocale from 'date-fns/locale/es'
-import enLocale from 'date-fns/locale/en-US'
 import { useStyles } from './TextField'
 import { KeyboardDatePickerProps } from '@material-ui/pickers/DatePicker'
 import { KeyboardDateTimePickerProps } from '@material-ui/pickers/DateTimePicker'
@@ -18,18 +15,12 @@ import { Omit } from 'ramda'
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date'
 
 interface IProps {
-    locale?: 'en-US' | 'pt-BR' | 'es'
+    locale?: DateFnsUtils['locale']
     type?: 'date' | 'time' | 'datetime'
     inputProps?: object
     onAuxClick?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void
     onAuxClickCapture?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void
     onChange(date: MaterialUiPickersDate | null, value?: string): void
-}
-
-const LOCALES = {
-    'es': esLocale,
-    'pt-BR': ptLocale,
-    'en-US': enLocale
 }
 
 const DEFAULT_FORMATS = {
@@ -56,7 +47,7 @@ const DateTime: FC<TProps> = ({
     invalidDateMessage = '',
     minDateMessage = '',
     maxDateMessage = '',
-    locale = 'pt-BR',
+    locale,
     type = 'date',
     ...otherProps
 }) => {
@@ -108,7 +99,7 @@ const DateTime: FC<TProps> = ({
     return (
         <MuiPickersUtilsProvider
             utils={ DateFnsUtils }
-            locale={ LOCALES[locale] }>
+            locale={ locale }>
             { type === 'date' && renderDatePicker() }
             { type === 'time' && renderTimePicker() }
             { type === 'datetime' && renderDateTimePicker() }

--- a/src/docz/DateTime.mdx
+++ b/src/docz/DateTime.mdx
@@ -5,15 +5,45 @@ route: /date-time
 
 import DateTime from '../core/DateTime'
 import { Playground, Props } from 'docz'
+import ptBRLocale from 'date-fns/locale/pt-BR'
+import ruLocale from 'date-fns/locale/ru'
 
 # DateTime
+
+This component uses the [date-fns v2](https://github.com/date-fns/date-fns)
+interfaces provided by [date-io](https://github.com/dmtrKovalenko/date-io),
+then if you need for a specific locale, follow in according with the example below:
+
+```jsx
+import ptBRLocale from 'date-fns/locale/pt-BR'
+
+<DateTime
+    locale={ ptBRLocale }
+    label='Data de Aniversário'
+    type='date'
+    margin={ 24 }
+    onChange={ () => null }
+    />
+```
+
+> The default locale is `en-US`
+
+### Default formats
+
+| type | format |
+| -- | -- |
+| date | 'dd/MM/yyyy' |
+| time | 'HH:mm' |
+| datetime | 'dd/MM/yyyy HH:mm' |
 
 ## Properties
 <Props of={ DateTime } />
 
 ## Demo
 <Playground>
-    <DateTime label='Birth date' type='date' margin={ 24 } onChange={ () => null } />
+    <DateTime label='Birth date' format='MM/dd/yyyy' type='date' margin={ 24 } onChange={ () => null } />
+    <DateTime label='Дата рождения' locale={ ruLocale } type='date' margin={ 24 } onChange={ () => null } />
+    <DateTime label='Data de aniversário' locale={ ptBRLocale } type='date' margin={ 24 } onChange={ () => null } />
     <DateTime label='Scrum' margin={ 24 } type='time' onChange={ () => null } />
     <DateTime label='Schedule meeting' margin={ 24 } type='datetime' onChange={ () => null } />
 </Playground>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3200,10 +3200,10 @@ d@1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-date-fns@2.0.0-alpha.27:
-  version "2.0.0-alpha.27"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.27.tgz#5ecd4204ef0e7064264039570f6e8afbc014481c"
-  integrity sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg==
+date-fns@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.4.1.tgz#b53f9bb65ae6bd9239437035710e01cf383b625e"
+  integrity sha512-2RhmH/sjDSCYW2F3ZQxOUx/I7PvzXpi89aQL2d3OAxSTwLx6NilATeUbe0menFE3Lu5lFkOFci36ivimwYHHxw==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Added more examples for DateTime and an emphasis about locales was made in the component description (Docz)