### PR TITLE
0.20.4 - Fix padding of TextField select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/TextField.tsx
+++ b/src/core/TextField.tsx
@@ -50,6 +50,9 @@ export const useStyles = makeStyles({
     },
     outlinedMultiline: {
         padding: '0px'
+    },
+    select: {
+        paddingRight: '34px'
     }
 })
 
@@ -88,7 +91,8 @@ const TextField: FC<TProps> = ({
                 classes: {
                     input: variant === 'outlined' ? classes.outlinedInput : '',
                     multiline:
-                        variant === 'outlined' ? classes.outlinedMultiline : ''
+                        variant === 'outlined' ? classes.outlinedMultiline : '',
+                    inputSelect: classes.select
                 },
                 ...InputProps
             } }

--- a/src/docz/TextField.mdx
+++ b/src/docz/TextField.mdx
@@ -29,3 +29,21 @@ import { Playground, Props } from 'docz'
         InputLabelProps={ { shrink: true } }
     />
 </Playground>
+
+## TextField select
+<Playground>
+    <TextField select value='reais'>
+        {
+            [
+                { label: 'R$', value: 'reais' },
+                { label: '$', value: 'dollar' }
+            ].map(({ label, value }) =>
+                <ListItem
+                    key={ value }
+                    value={ value }>
+                    { label }
+                </ListItem>
+            )
+        }
+    </TextField>
+</Playground>


### PR DESCRIPTION
Before:
![before-select](https://user-images.githubusercontent.com/11683201/67230435-af0e0b80-f413-11e9-97bf-04ff405063b2.png)

After:
![after-select](https://user-images.githubusercontent.com/11683201/67230437-b03f3880-f413-11e9-8dc5-2eb38c1ff328.png)
