### PR TITLE
0.21.16 - Enable disableRipper prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.21.15",
+  "version": "0.21.16",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/Tab.tsx
+++ b/src/core/Tab.tsx
@@ -7,6 +7,7 @@ interface IProps extends IDefault {
     icon?: string | JSX.Element
     label?: string
     value?: unknown
+    disableRipple?: boolean
 }
 
 class Tab extends Component<IProps> {
@@ -19,12 +20,14 @@ class Tab extends Component<IProps> {
         const {
             style,
             margin,
+            disableRipple,
             padding,
             ...otherProps
         } = this.props
 
         return (
             <MuiTab
+                disableRipple
                 style={ { margin, padding, ...style } }
                 { ...otherProps }
             />


### PR DESCRIPTION
- Allowing the use of `disableRipper` on `Tab` component. 