### PR TITLE
0.22.10 - Created prop to omit the number of rows at editable table select menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -6,7 +6,8 @@ import MaterialTable, {
     MTableBodyRow,
     MTableAction,
     MTableEditField,
-    MTableActions
+    MTableActions,
+    MTablePagination
 } from 'material-table'
 import {
     NoteAdd as IconAdd,
@@ -20,7 +21,7 @@ import {
     LastPage
 } from '../icons'
 import Typography from './Typography'
-import { equals } from 'ramda'
+import { equals, omit } from 'ramda'
 import styled from 'styled-components'
 import Button from './Button'
 import DateTime from './DateTime'
@@ -38,6 +39,7 @@ interface IProps<T extends object> {
     addIcon?: React.ReactElement
     deleteIcon?: React.ReactElement
     paginationInfo?: boolean
+    noMoreLines?: boolean
     noHeader?: boolean
     autoCompleteSuggestions?: TSuggestion[]
     autoCompleteField?: string
@@ -96,6 +98,13 @@ const CustomRows = styled(MTableBodyRow)`
     };
 `
 
+const RightPagination = styled.div`
+    .MTablePaginationInner-root-57 {
+        display: block;
+        float: right;
+    }
+`
+
 const usePrevious = (data?: object[]) => {
     const ref = useRef<object[] | undefined>()
 
@@ -125,7 +134,17 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
             </AddRowText>
         </AddRowButton>
 
-    const pagination = !props.paginationInfo && { Pagination: (() => null) }
+    const pagination = !props.paginationInfo
+        ? { Pagination: (() => null) }
+        : props.noMoreLines && {
+            Pagination: item =>
+                <RightPagination>
+                    <MTablePagination
+                        { ...omit(['classes'], item) }
+                    />
+                </RightPagination>
+        }
+
     const toolbar = props.noHeader && { Toolbar: (() => null) }
 
     const renderAutoComplete = inputProps =>
@@ -165,7 +184,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
         />
 
     return (
-        <div style={ { width: '100%' } } >
+        <div style={ { width: '100%', height: '300px' } } >
             <MaterialTable
                 components={ {
                     EditRow: props => <CustomRemove { ...props } />,

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -184,7 +184,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
         />
 
     return (
-        <div style={ { width: '100%', height: '300px' } } >
+        <div style={ { width: '100%' } } >
             <MaterialTable
                 components={ {
                     EditRow: props => <CustomRemove { ...props } />,
@@ -318,8 +318,12 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                         <IconChevronRight color={ props.color || 'primary' } />)
                 } }
                 style={ {
+                    display: 'flex',
                     border: '1px solid #CED4DE',
-                    boxShadow: 'none'
+                    boxShadow: 'none',
+                    height: '270px',
+                    justifyContent: 'space-between',
+                    flexDirection: 'column'
                 } }
                 columns={ props.columns || [] }
                 data={ data }

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -39,7 +39,7 @@ interface IProps<T extends object> {
     addIcon?: React.ReactElement
     deleteIcon?: React.ReactElement
     paginationInfo?: boolean
-    noMoreLines?: boolean
+    noRowsExpand?: boolean
     noHeader?: boolean
     autoCompleteSuggestions?: TSuggestion[]
     autoCompleteField?: string
@@ -136,7 +136,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
 
     const pagination = !props.paginationInfo
         ? { Pagination: (() => null) }
-        : props.noMoreLines && {
+        : props.noRowsExpand && {
             Pagination: item =>
                 <RightPagination>
                     <MTablePagination

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -16,7 +16,7 @@ import { Playground, Props } from 'docz'
     <EditableTable
         noHeader
         paginationInfo
-        noMoreLines
+        noRowsExpand
         title='adicionar'
         columns={[
             {   

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -15,6 +15,8 @@ import { Playground, Props } from 'docz'
 <Playground>
     <EditableTable
         noHeader
+        paginationInfo
+        noMoreLines
         title='adicionar'
         columns={[
             {   
@@ -57,6 +59,16 @@ import { Playground, Props } from 'docz'
                 readAt: new Date('05/15/2019 14:07'),
                 position: 5600, 
                 origin: 'S.0. 018774'
+            },
+              {
+                readAt: new Date('07/01/2019 19:22'),
+                position: 6451, 
+                origin: 'S.O. 3'
+            },
+            {
+                readAt: new Date('05/12/2019 14:07'),
+                position: 8000, 
+                origin: 'S.0. 018771'
             }
         ]}
     />


### PR DESCRIPTION
### Feature:
- Allowed the use of `noRowsExpand` prop to don't show the select number of rows menu.

### Fixes:
- Added a fixed size to the editable table body.