### PR TITLE
0.22.14 - Fix the pagination components position at Editable Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.13",
+  "version": "0.22.14",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -99,7 +99,7 @@ const CustomRows = styled(MTableBodyRow)`
 `
 
 const RightPagination = styled.div`
-    & div[class*=MTablePaginationInner-root] {
+    & > div {
         display: block;
         float: right;
     }


### PR DESCRIPTION
###Fix:
- Try another way to position the pagination component at table footer. 