### PR TITLE
0.22.15 - Fixed the pagination tooltips when the noExpandRows prop is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.14",
+  "version": "0.22.15",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",
@@ -31,7 +31,7 @@
     "@material-ui/lab": "4.0.0-alpha.42",
     "@material-ui/pickers": "3.2.6",
     "date-fns": "2.4.1",
-    "material-table": "1.56.1",
+    "material-table": "1.57.2",
     "ramda": "0.25.0",
     "react-number-format": "4.0.8"
   },

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -120,6 +120,39 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
     const previous = usePrevious(props.data)
     const addButtonColor = (props.color !== 'disabled' && props.color) || 'primary'
 
+    const localization = {
+        body: {
+            dateTimePickerLocalization: { locale: ptBRLocale },
+            emptyDataSourceMessage:
+                'Não há dados para serem exibidos no momento',
+            editRow: {
+                saveTooltip: 'Salvar',
+                cancelTooltip: 'Cancelar',
+                deleteText:
+                    'Você tem certeza que deseja excluir esse '
+                    + props.title + '?'
+            },
+            addTooltip: 'Adicionar ' + props.title,
+            deleteTooltip: 'Remover ' + props.title,
+            editTooltip: 'Editar ' + props.title
+        },
+        header: {
+            actions: ''
+        },
+        pagination: {
+            firstTooltip: 'Primeira',
+            firstAriaLabel: 'Primeira',
+            previousTooltip: 'Anterior',
+            previousAriaLabel: 'Anterior',
+            nextTooltip: 'Próxima',
+            nextAriaLabel: 'Próxima',
+            lastTooltip: 'Ultima',
+            lastAriaLabel: 'Ulima',
+            labelRowsSelect: 'Linhas',
+            labelDisplayedRows: '{from}-{to} de {count}'
+        }
+    }
+
     useEffect(() => {
         if (props.data && !equals(props.data, previous)) {
             setData(props.data)
@@ -141,6 +174,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                 <RightPagination>
                     <MTablePagination
                         { ...omit(['classes'], item) }
+                        localization={ localization.pagination }
                     />
                 </RightPagination>
         }
@@ -248,37 +282,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                     ...pagination,
                     ...toolbar
                 } }
-                localization={ {
-                    body: {
-                        dateTimePickerLocalization: { locale: ptBRLocale },
-                        emptyDataSourceMessage:
-                            'Não há dados para serem exibidos no momento',
-                        editRow: {
-                            saveTooltip: 'Salvar',
-                            cancelTooltip: 'Cancelar',
-                            deleteText:
-                                'Você tem certeza que deseja excluir esse '
-                                + props.title + '?'
-                        },
-                        addTooltip: 'Adicionar ' + props.title,
-                        deleteTooltip: 'Remover ' + props.title,
-                        editTooltip: 'Editar ' + props.title
-                    },
-                    header: {
-                        actions: ''
-                    },
-                    pagination: {
-                        firstTooltip: 'Primeira',
-                        firstAriaLabel: 'Primeira',
-                        previousTooltip: 'Anterior',
-                        previousAriaLabel: 'Anterior',
-                        nextTooltip: 'Próxima',
-                        nextAriaLabel: 'Próxima',
-                        lastTooltip: 'Ultima',
-                        lastAriaLabel: 'Ulima',
-                        labelRowsSelect: 'Linhas'
-                    }
-                } }
+                localization={ localization }
                 icons={ {
                     Add: forwardRef(() => renderAddComponent()),
                     Delete: forwardRef(() =>
@@ -321,7 +325,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                     display: 'flex',
                     border: '1px solid #CED4DE',
                     boxShadow: 'none',
-                    height: '270px',
+                    height: props.noRowsExpand ? '270px' : undefined,
                     justifyContent: 'space-between',
                     flexDirection: 'column'
                 } }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7459,10 +7459,10 @@ match-sorter@^3.0.0:
   dependencies:
     remove-accents "0.4.2"
 
-material-table@1.56.1:
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/material-table/-/material-table-1.56.1.tgz#40be8c3430df4db62ad9bd0548051104db70b379"
-  integrity sha512-j1424uQxExXXTMaED4MI0ROw7gIq2R3bUo4yVrSH6rPwxc1TPjoNytOkW1i+h5YmXzHQ7Ak+ERlehUz8g5OgpA==
+material-table@1.57.2:
+  version "1.57.2"
+  resolved "https://registry.yarnpkg.com/material-table/-/material-table-1.57.2.tgz#8854cb4d623b294138c83a0c7ff9f2900267c81f"
+  integrity sha512-hiJdRTrqu8pyYwSxzmcG1TnR4KWG2gtXrFB3XL9h4ij3A68EOJmlss6VH/LXh3NLlUce1TteK6W7fGa7YcnKGg==
   dependencies:
     "@date-io/date-fns" "^1.1.0"
     "@material-ui/pickers" "^3.2.2"


### PR DESCRIPTION
### General fixes:
  - Fixed the pagination tooltips when the `noExpandRows` is passed to the `EditableTable` component;
  - Added verification to put a fixed size only when `noExpandRows` is active;
  - Updated the Material-Table dependency to the last stable version. 