### PR TITLE
0.22.18 - Add MaskField in EditableTable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.17",
+  "version": "0.22.18",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "@material-ui/lab": "4.0.0-alpha.44",
     "@material-ui/pickers": "3.2.6",
     "date-fns": "2.4.1",
-    "material-table": "1.57.2",
+    "material-table": "1.59.0",
     "ramda": "0.25.0",
-    "react-number-format": "4.0.8"
+    "react-number-format": "4.4.1"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -238,6 +238,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                             'position' in props.action &&
                             props.action.position === 'toolbar'
                         ) {
+                            const ActionIcon = props.action.icon
 
                             return (
                                 <Button
@@ -245,7 +246,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                                     variant='dashed'
                                     color={ props.color || 'primary' }
                                     onClick={ props.action.onClick }>
-                                    { props.action.icon }
+                                    <ActionIcon />
                                 </Button>
                             )
                         }

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -29,6 +29,7 @@ import ptBRLocale from 'date-fns/locale/pt-BR'
 import AutoComplete from './AutoComplete'
 import ListItem from './ListItem'
 import TextField from './TextField'
+import MaskField from './MaskField'
 
 interface IProps<T extends object> {
     title?: string
@@ -43,6 +44,7 @@ interface IProps<T extends object> {
     noHeader?: boolean
     autoCompleteSuggestions?: TSuggestion[]
     autoCompleteField?: string
+    onRowClick?: (event?: React.MouseEvent, rowData?: T) => void
     onUpdateRow?: (newData: object, oldData?: object) => Promise<void>
     onDeleteRow?: (newData: object, oldData?: object) => Promise<void>
     onAddRow?: (oldData: object) => Promise<void>
@@ -220,6 +222,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
     return (
         <div style={ { width: '100%' } } >
             <MaterialTable
+                onRowClick={ props.onRowClick }
                 components={ {
                     EditRow: props => <CustomRemove { ...props } />,
                     Row: props => <CustomRows { ...props } />,
@@ -256,6 +259,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                     },
                     EditField: localProps => {
                         if (localProps.columnDef.type === 'datetime') {
+
                             return (
                                 <DateTime
                                     name={ localProps.columnDef.field + '-input' }
@@ -267,10 +271,24 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                             )
                         }
 
+                        if (localProps.columnDef.type === 'numeric') {
+
+                            return (
+                                <MaskField
+                                    thousandSeparator='.'
+                                    decimalSeparator=','
+                                    name={ localProps.columnDef.field + '-input' }
+                                    type={ localProps.columnDef.type }
+                                    value={ localProps.value }
+                                />
+                            )
+                        }
+
                         if (
                             localProps.columnDef.field === props.autoCompleteField &&
                             props.autoCompleteSuggestions
                         ) {
+
                             return renderAutoComplete(localProps)
                         }
 

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -37,8 +37,6 @@ interface IProps<T extends object> {
     columns?: Column<object>[]
     data?: T[]
     options?: Options
-    addIcon?: React.ReactElement
-    deleteIcon?: React.ReactElement
     paginationInfo?: boolean
     noRowsExpand?: boolean
     noHeader?: boolean
@@ -110,9 +108,7 @@ const RightPagination = styled.div`
 const usePrevious = (data?: object[]) => {
     const ref = useRef<object[] | undefined>()
 
-    useEffect(() => {
-        ref.current = data
-    })
+    useEffect(() => { ref.current = data })
 
     return ref.current
 }
@@ -242,7 +238,6 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                             'position' in props.action &&
                             props.action.position === 'toolbar'
                         ) {
-                            const Label = props.action.icon
 
                             return (
                                 <Button
@@ -250,7 +245,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                                     variant='dashed'
                                     color={ props.color || 'primary' }
                                     onClick={ props.action.onClick }>
-                                    <Label />
+                                    { props.action.icon }
                                 </Button>
                             )
                         }
@@ -275,11 +270,16 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
 
                             return (
                                 <MaskField
+                                    type='text'
                                     thousandSeparator='.'
                                     decimalSeparator=','
                                     name={ localProps.columnDef.field + '-input' }
-                                    type={ localProps.columnDef.type }
                                     value={ localProps.value }
+                                    onChange={
+                                        event => localProps.onChange(
+                                            event.currentTarget.value
+                                        )
+                                    }
                                 />
                             )
                         }
@@ -358,9 +358,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                     actionsColumnIndex: 4,
                     toolbarButtonAlignment: 'left',
                     padding: 'dense',
-                    headerStyle: {
-                        borderBottom: '2px #CED4DE solid'
-                    },
+                    headerStyle: { borderBottom: '2px #CED4DE solid' },
                     ...props.options
                 } }
                 editable={ {

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -17,6 +17,7 @@ import { Playground, Props } from 'docz'
         noHeader
         paginationInfo
         noRowsExpand
+        onRowClick={ (item, data) => console.log(data) }
         title='adicionar'
         columns={[
             {   
@@ -108,7 +109,7 @@ import { Playground, Props } from 'docz'
                 },
                 { 
                     title: 'Posição', 
-                    field: 'position', 
+                    field: 'position',
                     type: 'numeric' 
                 }
             ]

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -17,7 +17,7 @@ import { Playground, Props } from 'docz'
         noHeader
         paginationInfo
         noRowsExpand
-        onRowClick={ (item, data) => console.log(data) }
+        onRowClick={ () => window.alert('hello') }
         title='adicionar'
         columns={[
             {   

--- a/yarn.lock
+++ b/yarn.lock
@@ -7459,10 +7459,10 @@ match-sorter@^3.0.0:
   dependencies:
     remove-accents "0.4.2"
 
-material-table@1.57.2:
-  version "1.57.2"
-  resolved "https://registry.yarnpkg.com/material-table/-/material-table-1.57.2.tgz#8854cb4d623b294138c83a0c7ff9f2900267c81f"
-  integrity sha512-hiJdRTrqu8pyYwSxzmcG1TnR4KWG2gtXrFB3XL9h4ij3A68EOJmlss6VH/LXh3NLlUce1TteK6W7fGa7YcnKGg==
+material-table@1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/material-table/-/material-table-1.59.0.tgz#fb1d5cafbd4322d113805a923afe9fcd54d34157"
+  integrity sha512-gI18QcQhtmLoMGuYdhZEdtVBQurgZkB6BGuo4PF5HogoBycJyfy3qbrjLkprLXV4WrZoBZjRThFUEKq4z6zclg==
   dependencies:
     "@date-io/date-fns" "^1.1.0"
     "@material-ui/pickers" "^3.2.2"
@@ -9036,10 +9036,10 @@ react-live@2.0.1:
     react-simple-code-editor "^0.9.0"
     unescape "^0.2.0"
 
-react-number-format@4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.0.8.tgz#f0a0dfbeded9a746f4d8b309926cf55d7effebb2"
-  integrity sha512-A7Gi4BSkdgnyY1DO98lwFvWujcyxZCOfNP6tkiOKkwMY6oFP+JTQhd/vQ9dXXs6TpyXfl1eBJdueokM7o98YTQ==
+react-number-format@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.4.1.tgz#d5614dd25edfc21ed48b97356213440081437a94"
+  integrity sha512-ZGFMXZ0U7DcmQ3bSZY3FULOA1mfqreT9NIMYZNoa/ouiSgiTQiYA95Uj2KN8ge6BRr+ghA5vraozqWqsHZQw3Q==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
- Was enabled the use of `MaskField` inside `EditableTable`;
- Allowed the onRowClick prop on `EditableTable`; 
- Removed unecessary props;
- Updated the  react-number-format and material-table dependency. 