### PR TITLE
0.22.19 - MaskField on EditableTable component is accepting only integers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "node-fetch": "2.6.0",
     "prettier": "1.16.4",
     "styled-components": "5.0.0",
-    "typescript": "3.7.5"
+    "typescript": "3.9.5"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -271,9 +271,11 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
 
                             return (
                                 <MaskField
+                                    fixedDecimalScale
                                     type='text'
                                     thousandSeparator='.'
                                     decimalSeparator=','
+                                    decimalScale={ 0 }
                                     name={ localProps.columnDef.field + '-input' }
                                     value={ localProps.value }
                                     onChange={

--- a/yarn.lock
+++ b/yarn.lock
@@ -10803,10 +10803,10 @@ typescript@3.3.4000:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
   integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
- Passed props to render the number values only as Integers in `EditableTable` component. 