### PR TITLE
0.22.23 - Removed, temporarily, Props from docz mdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+<!-- Logo -->
+<p align="center">
+  <img width="150" src="logo.png" alt="Flipper-UI logo" />
+</p>
+
+<!-- Name -->
+<h1 align="center">Flipper-UI</h1>
+
+<!-- Badges -->
+<div align="center">
+
+[React](http://facebook.github.io/react/) UI toolkit for the web.
+
+[![npm package](https://img.shields.io/npm/v/flipper-ui/latest.svg)](https://www.npmjs.com/package/flipper-ui)
+[![npm downloads](https://img.shields.io/npm/dm/flipper-ui.svg)](https://www.npmjs.com/package/flipper-ui)
+[![Dependencies](https://img.shields.io/david/nginformatica/flipper-ui.svg?style=flat-square)](https://david-dm.org/nginformatica/flipper-ui)
+[![DevDependencies](https://img.shields.io/david/dev/nginformatica/flipper-ui.svg)](https://david-dm.org/nginformatica/flipper-ui?type=dev)
+[![Build Status](https://travis-ci.org/nginformatica/flipper-ui.svg?branch=master)](https://travis-ci.org/nginformatica/flipper-ui)
+
+</div>
+
+## Installation
+
+Flipper-UI is available as an [npm package](https://www.npmjs.com/package/flipper-ui).
+
+```sh
+// with npm
+npm install flipper-ui
+
+// with yarn
+yarn add flipper-ui
+```
+
+## Usage
+
+Here is a quick example to get you started, **it's all you need**:
+
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Button } from 'flipper-ui'
+
+function App() {
+  return (
+    <Button variant="contained" color="primary">
+      Hello World
+    </Button>
+  );
+}
+
+ReactDOM.render(<App />, document.querySelector('#app'));
+```
+
+## Components
+
+- [x] Advertise
+- [x] AppBar/Header
+- [x] AutoComplete
+- [x] Avatar
+- [x] Badge
+- [x] Box
+- [x] Button
+- [x] Checkbox
+- [x] Chip
+- [x] Collapse
+- [x] DatePicker
+- [x] Dialog
+- [x] Divider
+- [x] Expansion Panel
+- [x] Menu
+- [x] Fade
+- [x] Floating Action Button
+- [x] Grow
+- [x] Icon
+- [x] Icon Button
+- [x] List
+- [x] ListItem
+- [x] Paper
+- [x] Progress
+- [x] Sidebar/Drawer
+- [x] Switcher
+- [x] Radio
+- [x] RadioGroup
+- [x] Select
+- [x] Slide
+- [x] Snackbar
+- [x] Table
+- [x] Tabs
+- [x] TextArea
+- [x] TextField
+- [x] Tooltip
+- [x] Typography
+- [x] Zoom
+
+## Next Components
+
+- [ ] Carousel/Gallery
+- [ ] Tree
+
+## Documentation
+
+Check out our [documentation website](https://nginformatica.github.io/flipper-ui/).
+
+## Contributing
+
+Bug reports, feature requests and other contributions are more than welcome! <br/>
+Whenever possible, please make a pull request with the implementation instead of just requesting it.
+
+> If the feature is big, open an issue first for discussion.
+
+## License
+
+This project is licensed under the terms of the
+[MIT license](/LICENSE).

--- a/doczrc.js
+++ b/doczrc.js
@@ -2,6 +2,5 @@ export default {
     typescript: true,
     dest: '/docs',
     description: 'Flipper-ui React Components',
-    wrapper: '../../src/docz/Wrapper.tsx',
-    hashRouter:true
+    wrapper: '../../src/docz/Wrapper.tsx'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.22.22",
+  "version": "0.22.23",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://nginformatica.github.io/flipper-ui/",

--- a/src/docz/Advertise.mdx
+++ b/src/docz/Advertise.mdx
@@ -4,12 +4,9 @@ route: /advertise
 ---
 
 import Advertise from '../core/Advertise'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 
 # Advertise
-
-## Properties
-<Props of={ Advertise } />
 
 ## Demo
 <Playground style={ { padding: '10px', backgroundColor: 'silver' } }>

--- a/src/docz/Box.mdx
+++ b/src/docz/Box.mdx
@@ -4,12 +4,9 @@ route: /box
 ---
 
 import Box from '../core/Box'
-import { Playground, Props } from 'docz'
+import { Playground, } from 'docz'
 
 # Box
-
-## Properties
-<Props of={ Box } />
 
 ## Demo
 <Playground style={ { padding: '10px', backgroundColor: 'silver' } }>

--- a/src/docz/Header.mdx
+++ b/src/docz/Header.mdx
@@ -4,12 +4,9 @@ route: /header
 ---
 
 import Header from '../core/Header'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 
 # Header
-
-## Properties
-<Props of={ Header } />
 
 ## Demo
 <Playground>

--- a/src/docz/Index.mdx
+++ b/src/docz/Index.mdx
@@ -1,22 +1,13 @@
+---
+name: Index
+route: /
+---
+import imageUrl from '../../logo.png'
+
 <!-- Logo -->
-<p align="center">
-  <img width="150" src="logo.png" alt="Flipper-UI logo" />
-</p>
-
-<!-- Name -->
-<h1 align="center">Flipper-UI</h1>
-
-<!-- Badges -->
-<div align="center">
-
-[React](http://facebook.github.io/react/) UI toolkit for the web.
-
-[![npm package](https://img.shields.io/npm/v/flipper-ui/latest.svg)](https://www.npmjs.com/package/flipper-ui)
-[![npm downloads](https://img.shields.io/npm/dm/flipper-ui.svg)](https://www.npmjs.com/package/flipper-ui)
-[![Dependencies](https://img.shields.io/david/nginformatica/flipper-ui.svg?style=flat-square)](https://david-dm.org/nginformatica/flipper-ui)
-[![DevDependencies](https://img.shields.io/david/dev/nginformatica/flipper-ui.svg)](https://david-dm.org/nginformatica/flipper-ui?type=dev)
-[![Build Status](https://travis-ci.org/nginformatica/flipper-ui.svg?branch=master)](https://travis-ci.org/nginformatica/flipper-ui)
-
+<div style={{ display: 'flex', justifyContent: 'center', marginTop: '30px' }}>
+  <img width="150" src={imageUrl} alt="Flipper-UI logo" />
+  <h1 align="center" style={{ marginLeft: "4px"}}>Flipper-UI</h1>
 </div>
 
 ## Installation

--- a/src/docz/Sidebar.mdx
+++ b/src/docz/Sidebar.mdx
@@ -8,12 +8,9 @@ import Container from '../core/Container'
 import List from '../core/List'
 import ListItem from '../core/ListItem'
 import { Backup as IconBackup } from '../icons'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 
 # Sidebar
-
-## Properties
-<Props of={ Sidebar } />
 
 ## Normal
 <Playground>

--- a/src/docz/Stepper.mdx
+++ b/src/docz/Stepper.mdx
@@ -5,12 +5,9 @@ route: /stepper
 
 import Stepper from '../core/Stepper'
 import { Delete } from '../icons'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 
 # Stepper
-
-## Properties
-<Props of={ Stepper } />
 
 ## Demo
 <Playground>

--- a/src/docz/Tabs.mdx
+++ b/src/docz/Tabs.mdx
@@ -5,12 +5,9 @@ route: /tabs
 
 import Tabs from '../core/Tabs'
 import Tab from '../core/Tab'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 
 # Tabs
-
-## Properties
-<Props of={ Tabs } />
 
 ## Demo
 <Playground>

--- a/src/docz/Tooltip.mdx
+++ b/src/docz/Tooltip.mdx
@@ -5,13 +5,10 @@ route: /tooltip
 
 import Tooltip from '../core/Tooltip'
 import Button from '../core/Button'
-import { Playground, Props } from 'docz'
+import { Playground } from 'docz'
 import { Add as IconAdd } from '../icons'
 
 # Tooltip
-
-## Properties
-<Props of={ Tooltip } />
 
 ## Simple tooltip
 <Playground>


### PR DESCRIPTION
- Removed, for now, the Props component at mdx examples; 
- Created index for docz-vercel; 
- Removed hashRouter from the `doczrc.js` configs. 