### PR TITLE
0.23.1 - Allowed the disable add button prop on Editable Table component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -14,9 +14,10 @@ import { Playground, Props } from 'docz'
 ## Default
 <Playground>
     <EditableTable
-        noHeader
         paginationInfo
         noRowsExpand
+        disableAddHeader
+        onAddRow={ item => Promise.resolve(console.log(item)) }
         onRowClick={ () => window.alert('hello') }
         title='adicionar'
         columns={[


### PR DESCRIPTION
## Features:
 - Added `disableAddHeader` prop, to disable the Add button on table's header. 
 - Allowed the `errors` prop that receive a list of errors when the values of fields are changed.
