### PR TITLE
0.24.4 - Use the fullWidth prop on the Text Field component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/TextField.tsx
+++ b/src/core/TextField.tsx
@@ -107,6 +107,7 @@ const TextField: FC<TProps> = ({
     return (
         <TextFieldWrapper>
             <MuiTextField
+                fullWidth={ fullWidth }
                 autoComplete={ autoComplete }
                 error={ error }
                 variant={ variant as 'outlined' }


### PR DESCRIPTION
## FIXES:

- pass the `fullWidth` prop in `TextField` instead spread the values. 