### PR TITLE
0.24.7 - Create a specific helper warper for the ExpansionPanel component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/Checkbox.tsx
+++ b/src/core/Checkbox.tsx
@@ -21,6 +21,8 @@ interface IProps extends IDefault {
     onChange?: (event: ChangeEvent<HTMLElement>) => void
 }
 
+const DENSE = { padding: '2px', margin: '0px 7px' }
+
 const Checkbox = (props: IProps) => {
     const {
         type = 'checkbox',
@@ -46,20 +48,18 @@ const Checkbox = (props: IProps) => {
 
     const renderCheckbox = () =>
         <MuiCheckbox
+            { ...props }
             checked={ props.checked }
             value={ props.name }
             color={ props.color }
-            style={
-                props.dense
-                    ? { padding: '2px', margin: '0px 7px' }
-                    : {}
-            }
+            style={ props.dense ? DENSE : {} }
             disabled={ props.disabled }
             onChange={ props.onChange }
         />
 
     const renderSwitch = () =>
         <MuiSwitch
+            { ...props }
             checked={ props.checked }
             value={ props.name }
             color={ props.color }

--- a/src/core/ExpansionPanel.tsx
+++ b/src/core/ExpansionPanel.tsx
@@ -3,11 +3,9 @@ import MuiExpansionPanelActions from '@material-ui/core/ExpansionPanelActions'
 import MuiExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 import MuiExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
 import React, { ReactNode, FC, MouseEvent } from 'react'
+import styled from 'styled-components'
 import { IProps as IPaper } from './Paper'
-import {
-    HelperBox,
-    TextFieldWrapper as ExpansionPanelHeaderWrapper
-} from './TextField'
+import { HelperBox } from './TextField'
 
 interface IProps extends IPaper {
     actions?: ReactNode
@@ -25,6 +23,18 @@ interface IProps extends IPaper {
     onHelperClick?: () => void
     onChange?: (event?, expanded?) => void
 }
+
+const ExpansionPanelHeaderWrapper = styled.div`
+    display: flex;
+    flex-direction: rows;
+    align-items: center;
+    button {
+        display: none;  
+    }
+    :hover button {
+        display: flex;
+    }
+`
 
 const ExpansionPanel: FC<IProps> = ({
     actions,


### PR DESCRIPTION
## Improvements:
- Add `ExpansionPanelHeaderWrapper` on the `ExpansionPanel` component instead use the generic wrapper;
- Pass the default props to the `CheckBox` components.