### PR TITLE
0.24.8 - Remove the props spread to Switch and `CheckBox` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.7",
+  "version": "0.24.8",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/Checkbox.tsx
+++ b/src/core/Checkbox.tsx
@@ -48,7 +48,6 @@ const Checkbox = (props: IProps) => {
 
     const renderCheckbox = () =>
         <MuiCheckbox
-            id={ props.id }
             name={ props.name }
             checked={ props.checked }
             value={ props.name }
@@ -60,7 +59,6 @@ const Checkbox = (props: IProps) => {
 
     const renderSwitch = () =>
         <MuiSwitch
-            id={ props.id }
             name={ props.name }
             checked={ props.checked }
             value={ props.name }
@@ -83,7 +81,7 @@ const Checkbox = (props: IProps) => {
             : props.label
 
     return (
-        <CheckFieldsWrapper>
+        <CheckFieldsWrapper id={ props.id }>
             {
                 props.label
                     ? (

--- a/src/core/Checkbox.tsx
+++ b/src/core/Checkbox.tsx
@@ -48,7 +48,8 @@ const Checkbox = (props: IProps) => {
 
     const renderCheckbox = () =>
         <MuiCheckbox
-            { ...props }
+            id={ props.id }
+            name={ props.name }
             checked={ props.checked }
             value={ props.name }
             color={ props.color }
@@ -59,7 +60,8 @@ const Checkbox = (props: IProps) => {
 
     const renderSwitch = () =>
         <MuiSwitch
-            { ...props }
+            id={ props.id }
+            name={ props.name }
             checked={ props.checked }
             value={ props.name }
             color={ props.color }

--- a/src/docz/Checkbox.mdx
+++ b/src/docz/Checkbox.mdx
@@ -61,6 +61,7 @@ import { Playground, Props } from 'docz'
 ## Switch with helper
 <Playground>
     <Checkbox
+        id="with-helper"
         onHelperClick={ () => alert('Do you need help?') }
         name='bluetooth'
         type='switch'


### PR DESCRIPTION
## FIxes:

- Pass only id and name instead all the props to  `Switch` and `CheckBox` material-ui components.