### PR TITLE
0.24.10 - Positioning the EditableTable's MaskField always on the right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -27,3 +27,7 @@ export const error = {
 
 export const warning = '#FFC107'
 export const success = '#4CAF50'
+
+// Table gradient hover colors with opacity
+export const DARK = 'rgba(189,189,189,0)'
+export const GREY = 'rgba(189,189,189,1)'

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -1,0 +1,30 @@
+import ptBRLocale from 'date-fns/locale/pt-BR'
+
+export const getLocalization = (title: string = '') => ({
+    body: {
+        dateTimePickerLocalization: { locale: ptBRLocale },
+        emptyDataSourceMessage: 'Não há dados para serem exibidos no momento',
+        editRow: {
+            saveTooltip: 'Salvar',
+            cancelTooltip: 'Cancelar',
+            deleteText:
+                `Você tem certeza que deseja excluir esse ${title ?? 'item'}?`
+        },
+        addTooltip: `Adicionar ${title}`,
+        deleteTooltip: `Remover ${title}`,
+        editTooltip: `Editar ${title}`
+    },
+    header: { actions: '' },
+    pagination: {
+        firstTooltip: 'Primeira',
+        firstAriaLabel: 'Primeira',
+        previousTooltip: 'Anterior',
+        previousAriaLabel: 'Anterior',
+        nextTooltip: 'Próxima',
+        nextAriaLabel: 'Próxima',
+        lastTooltip: 'Ultima',
+        lastAriaLabel: 'Ulima',
+        labelRowsSelect: 'Linhas',
+        labelDisplayedRows: '{from}-{to} de {count}'
+    }
+})


### PR DESCRIPTION
## Fixes

- Aligned the `MaskField` of the `EditableTable` component on the right with the column title.

## Improvements

- Moved the localization object to a function `getLocalization`, created a file for that function on the new lib directory.