### PR TITLE
0.24.11 - Changed to optional the row edit cancel functions on EditableTable component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.10",
+  "version": "0.24.11",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -51,8 +51,8 @@ interface IProps<T extends object> {
     onUpdateRow?: (newData: object, oldData?: object) => Promise<void>
     onDeleteRow?: (newData: object, oldData?: object) => Promise<void>
     onAddRow?: (oldData: object) => Promise<void>
-    onRowAddCancelled: (newData: object) => Promise<void>
-    onRowUpdateCancelled: (newData: object) => Promise<void>
+    onRowAddCancelled?: (newData: object) => Promise<void>
+    onRowUpdateCancelled?: (newData: object) => Promise<void>
     onClickAdd?(): void
 }
 


### PR DESCRIPTION
## Fixes:
- Altered the props `onRowAddCancelled` and `onRowUpdateCancelled` to optional in order to avoid errors/warns. 