### PR TITLE
0.24.12 - Fixed default font on rowStyle in EditableTable component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.11",
+  "version": "0.24.12",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -330,6 +330,9 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                     actionsColumnIndex: 4,
                     toolbarButtonAlignment: 'left',
                     padding: 'dense',
+                    rowStyle: {
+                        fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif;'
+                    },
                     headerStyle: { borderBottom: '2px #CED4DE solid' },
                     ...props.options
                 } }


### PR DESCRIPTION
### Fixes:

- Pass a default `fontFamily` (Roboto) as `rowStyle` prop to `EditableTable` to avoid fonts inheritance issues.
 
https://github.com/mbrn/material-table/issues/2080
