### PR TITLE
0.24.13 - Improved error handling on EditableTable component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.24.12",
+  "version": "0.24.13",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.vercel.app",

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -242,7 +242,10 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
 
                             return (
                                 <DateTime
-                                    error={ getErrors(localProps.columnDef.field) }
+                                    error={ props.errors
+                                        ? getErrors(localProps.columnDef.field)
+                                        : localProps.error
+                                    }
                                     name={ localProps.columnDef.field + '-input' }
                                     type={ localProps.columnDef.type }
                                     value={ localProps.value }

--- a/src/core/EditableTable.tsx
+++ b/src/core/EditableTable.tsx
@@ -120,8 +120,9 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
     const renderMaskField = (item, error: boolean) =>
         <Wrapper>
             <MaskField
+                { ...item }
                 fixedDecimalScale
-                error={ error }
+                error={ props.errors ? error : item.error }
                 type='text'
                 thousandSeparator='.'
                 decimalSeparator=','
@@ -137,11 +138,12 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
             />
         </Wrapper>
 
-    const renderAddComponent = () =>
+    const renderAddComponent = (
         <AddRowButton data-id='add-row'>
             <IconAdd />
             <AddRowText> Adicionar { props.title } </AddRowText>
         </AddRowButton>
+    )
 
     const pagination = !props.paginationInfo
         ? { Pagination: (() => null) }
@@ -274,7 +276,7 @@ const EditableTable = <T extends object>(props: IProps<T>) => {
                 } }
                 localization={ getLocalization(props.title) }
                 icons={ {
-                    Add: forwardRef(() => renderAddComponent()),
+                    Add: forwardRef(() => renderAddComponent),
                     Delete: forwardRef(() =>
                         <IconRemove
                             name='row-remove'

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -17,38 +17,49 @@ import { Playground, Props } from 'docz'
 <Playground>
     {
         () => {
-            const [fieldError, setFieldError] = React.useState(false)
-            const [data, setData] = React.useState([{someTitle: 11}])
+            const [data, setData] = React.useState([
+                {someTitle: 11, readAt: new Date()}
+            ])
 
             const handleAdd = item => new Promise((resolve, reject) => {
                 if (item.someTitle < 10) {   
-                    setFieldError(true)
                     reject()
                 } else {
                     setData([...data, item])
-                    setFieldError(false)
                     resolve()
                 }
             })
 
             const handleUpdate = (newItem) => new Promise((resolve, reject) => {
-                if (newItem.someTitle < 10) {   
-                    setFieldError(true)
-                    reject()
-                } else {
+                const value = newItem.someTitle.toString().split('.').join('')
+
+                if (value > 10) {
                     setData([newItem])
-                    setFieldError(false)
                     resolve()
+                } else {
+                    reject()                
                 }
             })
 
-            const handleCancel = () => Promise.resolve(setFieldError(false))
+            const handleCancel = () => Promise.resolve()
+
+            const renderText = item => 
+                item.someTitle.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')
+
+            const validateField = item => {
+                if (item.someTitle) { 
+                    const value = item.someTitle.toString().split('.').join('')
+                                
+                    return value > 10 
+                }
+
+                return true 
+            }
 
             return (
                 <EditableTable
                     paginationInfo
                     noRowsExpand
-                    errors={ fieldError ? ['someTitle'] : [] }
                     onAddRow={handleAdd}
                     onUpdateRow={handleUpdate}
                     onRowUpdateCancelled={handleCancel}
@@ -58,7 +69,15 @@ import { Playground, Props } from 'docz'
                         {
                             title: 'some title',
                             field: 'someTitle',
-                            type: 'numeric'
+                            type: 'numeric',
+                            render: renderText,
+                            validate: validateField
+                        },
+                        {
+                            title: 'Leitura',
+                            field: 'readAt',
+                            initialEditValue: new Date(),
+                            type: 'datetime',
                         }
                     ]}
                     data={data}

--- a/src/docz/EditableTable.mdx
+++ b/src/docz/EditableTable.mdx
@@ -21,19 +21,20 @@ import { Playground, Props } from 'docz'
                 {someTitle: 11, readAt: new Date()}
             ])
 
+            const getValue = item => 
+                item.someTitle.toString().split('.').join('')
+
             const handleAdd = item => new Promise((resolve, reject) => {
-                if (item.someTitle < 10) {   
-                    reject()
-                } else {
+                if (getValue(item) > 10) {
                     setData([...data, item])
                     resolve()
+                } else {
+                    reject()
                 }
             })
 
             const handleUpdate = (newItem) => new Promise((resolve, reject) => {
-                const value = newItem.someTitle.toString().split('.').join('')
-
-                if (value > 10) {
+                if (getValue(newItem) > 10) {
                     setData([newItem])
                     resolve()
                 } else {
@@ -47,10 +48,8 @@ import { Playground, Props } from 'docz'
                 item.someTitle.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')
 
             const validateField = item => {
-                if (item.someTitle) { 
-                    const value = item.someTitle.toString().split('.').join('')
-                                
-                    return value > 10 
+                if (item.someTitle) {                                 
+                    return getValue(item) > 10 
                 }
 
                 return true 


### PR DESCRIPTION
## Improvements:

- Used the `material-table` error handling beside the custom error handler on numeric and date fields;
- To use it, it's necessary add the field `validate` on the `columns` object and not pass the errors array to `EditableTable`. 
- Added a more specific example using that new approach. 