### PR TITLE
hotfix(select): onChange props with event instead of its target value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.ngi.com.br/",

--- a/src/core/inputs/select/index.tsx
+++ b/src/core/inputs/select/index.tsx
@@ -20,7 +20,7 @@ export interface SelectProps
     children: React.ReactNode
     onClear?: () => void
     onClose?: () => void
-    onChange: (value: string) => void
+    onChange: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void
 }
 
 const iconStyle = {
@@ -62,7 +62,7 @@ export const Select = ({
     const handleChange = (
         event: ChangeEvent<HTMLSelectElement | HTMLInputElement>
     ) => {
-        onChange(event.target.value)
+        onChange(event)
     }
     const hasValue = !!otherProps.value
 

--- a/src/core/inputs/select/select.spec.tsx
+++ b/src/core/inputs/select/select.spec.tsx
@@ -42,7 +42,11 @@ describe('Select', () => {
         const option = screen.getByText('Option 1')
         await act(async () => await userEvent.click(option))
 
-        expect(onChangeSpy).toBeCalledWith('1')
+        expect(onChangeSpy).toBeCalledWith(
+            expect.objectContaining({
+                target: { value: '1', name: undefined }
+            })
+        )
     })
 
     it('should render with clear button', async () => {

--- a/src/core/inputs/select/select.stories.tsx
+++ b/src/core/inputs/select/select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { ChangeEvent, useState } from 'react'
 import { Meta } from '@storybook/react'
 import Select from '.'
 import ListItem from '@/core/data-display/list-item'
@@ -11,8 +11,10 @@ export default {
 export const Default = () => {
     const [select, setSelect] = useState('3')
 
-    function handleChange(value: string) {
-        setSelect(value)
+    function handleChange(
+        event: ChangeEvent<HTMLSelectElement | HTMLInputElement>
+    ) {
+        setSelect(event.target.value)
     }
 
     return (
@@ -32,8 +34,10 @@ export const Default = () => {
 export const WithClear = () => {
     const [select, setSelect] = useState('3')
 
-    function handleChange(value: string) {
-        setSelect(value)
+    function handleChange(
+        event: ChangeEvent<HTMLSelectElement | HTMLInputElement>
+    ) {
+        setSelect(event.target.value)
     }
 
     const handleClear = () => {

--- a/src/test/mocks/select-mock.tsx
+++ b/src/test/mocks/select-mock.tsx
@@ -10,8 +10,10 @@ interface IProps {
 const Default = (props: IProps) => {
     const [select, setSelect] = React.useState(props.initialValue || '')
 
-    function handleChange(value: string) {
-        setSelect(value)
+    function handleChange(
+        event: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>
+    ) {
+        setSelect(event.target.value)
     }
 
     const handleClear = () => {


### PR DESCRIPTION
Algumas implementações do componente no produto utilizam mais elementos do event do que somente seu value, entao foi necessário voltar a utilizar o event completo como parâmetro no callback