### PR TITLE
refactor(text-field): exported interface extending mui props making those props importable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.ngi.com.br/",

--- a/src/core/inputs/text-field/index.tsx
+++ b/src/core/inputs/text-field/index.tsx
@@ -22,7 +22,9 @@ import {
 import IconButton from '../icon-button'
 import styled from 'styled-components'
 
-export interface TextFieldProps extends DefaultProps {
+export interface TextFieldProps
+    extends DefaultProps,
+        Omit<MuiTextFieldProps, 'margin' | 'variant'> {
     autoComplete?: string
     autoFocus?: boolean
     defaultValue?: string | number
@@ -177,7 +179,7 @@ export const TextField = ({
     hasClear,
     onClear,
     ...otherProps
-}: TextFieldProps & Omit<MuiTextFieldProps, 'margin' | 'variant'>) => {
+}: TextFieldProps) => {
     const clearStyle = makeStyles({
         iconOutlined: {
             position: 'relative',


### PR DESCRIPTION
Estendendo a interface do material ui para que o ts consiga inferir os tipos corretamente, uma vez que a interface do MUi nao é exportada pelo Flipper, forçando ao client ter q importar o tipo diretamente do MUi