### PR TITLE
fix(Dialog): conditionally render title prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.ngi.com.br/",

--- a/src/core/feedback/dialog/dialog.spec.tsx
+++ b/src/core/feedback/dialog/dialog.spec.tsx
@@ -94,6 +94,7 @@ describe('Dialog', () => {
         render(
             <Dialog
                 open
+                aria-title='dialog-paper'
                 title='My beautiful Dialog'
                 text={'Is not it?'}
                 onClose={jest.fn()}
@@ -114,6 +115,7 @@ describe('Dialog', () => {
         render(
             <Dialog
                 open
+                aria-title='dialog-paper'
                 title='My beautiful Dialog'
                 text={'Is not it?'}
                 onClose={jest.fn()}
@@ -134,6 +136,7 @@ describe('Dialog', () => {
         render(
             <Dialog
                 open
+                aria-title='dialog-paper'
                 title='My beautiful Dialog'
                 text={'Is not it?'}
                 onClose={jest.fn()}
@@ -154,6 +157,7 @@ describe('Dialog', () => {
         render(
             <Dialog
                 open
+                aria-title='dialog-paper'
                 title='My beautiful Dialog'
                 text={'Is not it?'}
                 onClose={jest.fn()}

--- a/src/core/feedback/dialog/index.tsx
+++ b/src/core/feedback/dialog/index.tsx
@@ -32,6 +32,7 @@ export interface DialogProps
     snippetContentStyle?: CSSProperties
     contentTextStyle?: CSSProperties
     scroll?: 'body' | 'paper' | 'unset-paper' | 'unset-body'
+    'aria-title'?: string
     onClose?: (event: Event) => void
 }
 
@@ -86,6 +87,7 @@ export const Dialog = ({
     title,
     snippetStyle,
     snippetContentStyle,
+    'aria-title': ariaTitle,
     ...otherProps
 }: DialogProps) => {
     const classes = useStyles()
@@ -176,7 +178,7 @@ export const Dialog = ({
             maxWidth={maxWidth}
             scroll={scrollMode}
             PaperProps={{
-                title: 'dialog-paper',
+                ...(ariaTitle ? { title: ariaTitle } : {}),
                 classes:
                     scroll === 'unset-body' || scroll === 'unset-paper'
                         ? { root: classes.root }


### PR DESCRIPTION
Por default, a propriedade "title" é utilizada pelos navegadores para renderizar um tooltip da tag. 

Essa propriedade que estava presente para testes E2E no Dialog fazia com que o navegador renderizasse um tooltip escrito "dialog-paper".

Como essa propriedade é mais utilizada para acessibilidade, adicionou-se uma prop no Dialog chamada "aria-title", que recebe o titulo usado nos testes, se não for presente, não adiciona a propriedade "title" no Paper, evitando a renderização do tooltip.

![image](https://github.com/nginformatica/flipper-ui/assets/50382406/b0d51fee-db05-4e2a-bcc1-335b83f508c9)