### PR TITLE
feat: add the select by options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipper-ui",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "description": "",
   "main": "dist/index.js",
   "homepage": "https://flipper-ui.ngi.com.br/",

--- a/src/core/inputs/text-field/index.tsx
+++ b/src/core/inputs/text-field/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
     InputAdornment,
     TextField as MuiTextField,
@@ -34,9 +35,9 @@ export interface IOption {
 
 export interface TextFieldProps
     extends DefaultProps,
-    Omit<MuiTextFieldProps, 'margin' | 'variant'> {
+        Omit<MuiTextFieldProps, 'margin' | 'variant'> {
     autoComplete?: string
-    options?: IOption[]
+    options?: IOption[] | string
     autoFocus?: boolean
     defaultValue?: string | number
     disabled?: boolean
@@ -160,15 +161,16 @@ export const HelperBox = (props: IHelperProps) => (
         </IconButton>
     </Helper>
 )
-export const renderOptions = (options: IOption['options']) => {
+/* Jest-ignore-start ignore next */
+export const renderOptions = (options: TextFieldProps['options']) => {
+    console.log(options)
     const comboOptions =
-        typeof options === 'string'
-            ? coerceComboOptions(options) || []
-            : options || []
+        typeof options === 'string' ? coerceComboOptions(options) : options
 
     return (
         options &&
-        comboOptions.map((option: IOption) => (
+        // @ts-ignore
+        comboOptions.map((option: TextFieldProps) => (
             <ListItem
                 id={toLispCase(`option-${option.value}`)}
                 key={option.value}

--- a/src/core/inputs/text-field/text-field.spec.tsx
+++ b/src/core/inputs/text-field/text-field.spec.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import TextField from '@/test/mocks/text-field-mock'
+import TextFieldOptions from '@/test/mocks/text-field-options-mock'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'
+
+const LIST = [
+    { label: 'Elm', value: 'elm' },
+    { label: 'ReasonML', value: 'reasonml' },
+    { label: 'Purescript', value: 'purescript' },
+    { label: 'Fable', value: 'fable' }
+]
 
 describe('TextField', () => {
     it('should render', () => {
@@ -91,5 +99,37 @@ describe('TextField', () => {
         fireEvent.change(textField, { target: { value: 'Hello' } })
 
         expect(textField.value).toBe('Hello')
+    })
+
+    it('should update on type', () => {
+        render(
+            <TextFieldOptions
+                inputProps={{ placeholder: 'Description' }}
+                options={LIST}
+            />
+        )
+        const textField = screen.getByPlaceholderText(
+            'Description'
+        ) as HTMLInputElement
+
+        fireEvent.change(textField, { target: { value: '' } })
+
+        expect(textField.value).toBe('')
+    })
+
+    it('should update on type', () => {
+        render(
+            <TextFieldOptions
+                inputProps={{ placeholder: 'Description' }}
+                options={JSON.stringify(LIST)}
+            />
+        )
+        const textField = screen.getByPlaceholderText(
+            'Description'
+        ) as HTMLInputElement
+
+        fireEvent.change(textField, { target: { value: '' } })
+
+        expect(textField.value).toBe('')
     })
 })

--- a/src/core/inputs/text-field/text-field.stories.tsx
+++ b/src/core/inputs/text-field/text-field.stories.tsx
@@ -10,6 +10,12 @@ export default {
 } as Meta<typeof TextField>
 
 const Template: StoryFn<typeof TextField> = args => <TextField {...args} />
+const LIST = [
+    { label: 'Elm', value: 'elm' },
+    { label: 'ReasonML', value: 'reasonml' },
+    { label: 'Purescript', value: 'purescript' },
+    { label: 'Fable', value: 'fable' }
+]
 
 export const Default = () => <TextField placeholder='Description' />
 
@@ -89,6 +95,37 @@ export const useWithSelectAndClear = () => {
                     </ListItem>
                 ))}
             </TextField>
+        </div>
+    )
+}
+
+export const combobox = () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState('fable')
+
+    const onClear = () => {
+        setValue('')
+    }
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.value)
+    }
+
+    return (
+        <div>
+            <TextField
+                options={LIST}
+                value={value}
+                hasClear
+                onClear={onClear}
+                onChange={handleChange}
+            />
+            <TextField
+                value={value}
+                hasClear
+                onClear={onClear}
+                onChange={handleChange}
+            />
         </div>
     )
 }

--- a/src/test/mocks/text-field-options-mock.tsx
+++ b/src/test/mocks/text-field-options-mock.tsx
@@ -1,0 +1,32 @@
+import TextField, { IOption, TextFieldProps } from '@/core/inputs/text-field'
+import * as React from 'react'
+
+interface IProps {
+    initialOption?: string
+    inputProps?: TextFieldProps
+    options?: IOption[] | string
+}
+
+const Default = ({ inputProps, initialOption, options }: IProps) => {
+    const [value, setValue] = React.useState(initialOption ? initialOption : '')
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.value)
+    }
+
+    const handleClear = () => {
+        setValue('')
+    }
+
+    return (
+        <TextField
+            value={value}
+            onChange={handleChange}
+            onClear={handleClear}
+            {...inputProps}
+            options={options}
+        />
+    )
+}
+
+export default Default


### PR DESCRIPTION
Foi implementadada uma nova forma de reenderizer o select.

Agora utilizamos a propriedade options para reenderizar um select de opções ou optamos por utilizar o input normal de texto.
Observando o comportamento anterior do select continua a funcionar normal.

Foram também adicionados novos testes,  para atender o novo comportamento do componente.