### PR TITLE
Feat/allow cnpj with letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.40.1
+
+- add `allowAlphanumeric` prop to `<MaskField>` to allow letters in pattern-formatted fields (e.g. CNPJ with letters)
+
 ## v0.40.0
 
 - fix release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flipper-ui",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "author": "NG",
     "license": "MIT",
     "main": "dist/index.js",

--- a/src/core/inputs/mask-field/index.tsx
+++ b/src/core/inputs/mask-field/index.tsx
@@ -51,7 +51,7 @@ const MaskField = (props: MaskFieldProps) => {
         return (
             <NumberFormatBase
                 {...otherProps}
-                style={{ ...style, border: '1px solid red' }}
+                style={{ ...style }}
                 customInput={customInput || TextField}
                 isValidInputCharacter={char => /[0-9A-Za-z]/.test(char)}
                 isCharacterSame={({

--- a/src/core/inputs/mask-field/index.tsx
+++ b/src/core/inputs/mask-field/index.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import type { ComponentType, SyntheticEvent } from 'react'
 import type { NumberFormatValues, SourceInfo } from 'react-number-format'
-import { NumericFormat, PatternFormat } from 'react-number-format'
+import {
+    NumberFormatBase,
+    NumericFormat,
+    PatternFormat,
+    getPatternCaretBoundary,
+    patternFormatter
+} from 'react-number-format'
 import type { ITextFieldProps } from '@/core/inputs/text-field'
 import type { SourceType } from 'react-number-format/types/types'
 import TextField from '@/core/inputs/text-field'
@@ -16,6 +22,7 @@ export interface MaskFieldProps extends Omit<ITextFieldProps, 'size'> {
     fixedDecimalScale?: boolean
     customInput?: ComponentType<ITextFieldProps>
     hasFormat?: boolean
+    allowAlphanumeric?: boolean
     onValueChange?: (values: NumberFormatValues, sourceInfo: SourceInfo) => void
 }
 
@@ -34,10 +41,43 @@ const MaskField = (props: MaskFieldProps) => {
     const {
         customInput,
         hasFormat,
+        allowAlphanumeric,
         format = '######',
         style,
         ...otherProps
     } = props
+
+    if (hasFormat && allowAlphanumeric) {
+        return (
+            <NumberFormatBase
+                {...otherProps}
+                style={{ ...style, border: '1px solid red' }}
+                customInput={customInput || TextField}
+                isValidInputCharacter={char => /[0-9A-Za-z]/.test(char)}
+                isCharacterSame={({
+                    currentValue,
+                    formattedValue,
+                    currentValueIndex,
+                    formattedValueIndex
+                }) =>
+                    currentValue[currentValueIndex].toUpperCase() ===
+                    formattedValue[formattedValueIndex].toUpperCase()
+                }
+                format={value =>
+                    patternFormatter(value.toUpperCase(), {
+                        format,
+                        patternChar: '#'
+                    })
+                }
+                removeFormatting={value =>
+                    value.replace(/[^0-9A-Za-z]/g, '').toUpperCase()
+                }
+                getCaretBoundary={value =>
+                    getPatternCaretBoundary(value, { format, patternChar: '#' })
+                }
+            />
+        )
+    }
 
     return (
         <>

--- a/src/core/inputs/mask-field/mask-field.spec.tsx
+++ b/src/core/inputs/mask-field/mask-field.spec.tsx
@@ -51,4 +51,23 @@ describe('MaskField', () => {
 
         expect(container).toMatchSnapshot()
     })
+
+    it('should accept alphanumeric characters when allowAlphanumeric is set', async () => {
+        render(
+            <MaskField
+                hasFormat
+                allowAlphanumeric
+                placeholder='Description'
+                format='##.###.###/####-##'
+            />
+        )
+
+        const input = screen.getByPlaceholderText(
+            'Description'
+        ) as HTMLInputElement
+
+        await act(async () => await userEvent.type(input, '12abc678000195'))
+
+        expect(input.value).toBe('12.ABC.678/0001-95')
+    })
 })

--- a/src/core/inputs/mask-field/mask-field.stories.tsx
+++ b/src/core/inputs/mask-field/mask-field.stories.tsx
@@ -61,6 +61,7 @@ export const maskField: Story = {
     args: {
         label: 'Price',
         hasFormat: false,
+        allowAlphanumeric: false,
         format: '####',
         decimalScale: 2,
         decimalSeparator: ',',


### PR DESCRIPTION
- add `allowAlphanumeric` prop to `<MaskField>` to allow letters in pattern-formatted fields (e.g. CNPJ with letters)